### PR TITLE
Mock declarative delay and JAXRS implementation

### DIFF
--- a/examples/gatling/src/test/java/mock/mock.feature
+++ b/examples/gatling/src/test/java/mock/mock.feature
@@ -3,7 +3,6 @@ Feature: cats stateful crud
   Background:
     * def uuid = function(){ return java.util.UUID.randomUUID() + '' }
     * def cats = {}
-    * def delay = function(){ java.lang.Thread.sleep(850) }
 
   Scenario: pathMatches('/cats') && methodIs('post')
     * def cat = request
@@ -22,7 +21,7 @@ Feature: cats stateful crud
   Scenario: pathMatches('/cats/{id}') && methodIs('delete')
     * karate.remove('cats', '$.' + pathParams.id)
     * def response = ''
-    * def afterScenario = delay
+    * def responseDelay = 850
 
   Scenario: pathMatches('/cats/{id}')
     * def response = cats[pathParams.id]

--- a/examples/jobserver/src/test/java/jobtest/simple/simple1.feature
+++ b/examples/jobserver/src/test/java/jobtest/simple/simple1.feature
@@ -1,9 +1,7 @@
 Feature: simple 1
 
 Background:
-* print 'background: sleeping ...'
-* java.lang.Thread.sleep(1000)
-* print 'background: done'
+* configure responseDelay = 1000
 
 Scenario: 1-one
 * print '1-one'

--- a/karate-core/pom.xml
+++ b/karate-core/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <antlr.version>4.7.1</antlr.version>
         <netty.version>4.1.48.Final</netty.version>
+        <jersey.version>2.30</jersey.version>
     </properties>    
 
     <dependencies>
@@ -69,7 +70,12 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>4.0.3</version>
-        </dependency>                     
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/karate-core/src/main/java/com/intuit/karate/Config.java
+++ b/karate-core/src/main/java/com/intuit/karate/Config.java
@@ -63,6 +63,7 @@ public class Config {
     private ScriptValue headers = ScriptValue.NULL;
     private ScriptValue cookies = ScriptValue.NULL;
     private ScriptValue responseHeaders = ScriptValue.NULL;
+    private long responseDelay = 0L;
     private boolean lowerCaseResponseHeaders = false;
     private boolean corsEnabled = false;
     private boolean logPrettyRequest;
@@ -111,6 +112,9 @@ public class Config {
                 return false;
             case "responseHeaders":
                 responseHeaders = value;
+                return false;
+            case "responseDelay":
+                responseDelay = value.isNull() ? 0L : Double.valueOf(value.getAsString()).longValue();
                 return false;
             case "lowerCaseResponseHeaders":
                 lowerCaseResponseHeaders = value.isBooleanTrue();

--- a/karate-core/src/main/java/com/intuit/karate/Config.java
+++ b/karate-core/src/main/java/com/intuit/karate/Config.java
@@ -275,6 +275,7 @@ public class Config {
         headers = parent.headers;
         cookies = parent.cookies;
         responseHeaders = parent.responseHeaders;
+        responseDelay = parent.responseDelay;
         lowerCaseResponseHeaders = parent.lowerCaseResponseHeaders;
         corsEnabled = parent.corsEnabled;
         logPrettyRequest = parent.logPrettyRequest;
@@ -390,6 +391,10 @@ public class Config {
 
     public ScriptValue getResponseHeaders() {
         return responseHeaders;
+    }
+
+    public long getResponseDelay() {
+        return responseDelay;
     }
 
     public boolean isLowerCaseResponseHeaders() {

--- a/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
@@ -70,10 +70,12 @@ public class ScriptBindings implements Bindings {
     public static final String ACCEPT_CONTAINS = "acceptContains";
     public static final String HEADER_CONTAINS = "headerContains";
     public static final String PARAM_VALUE = "paramValue";
+    public static final String PARAM_CONTAINS = "paramContains";
     public static final String PATH_PARAMS = "pathParams";
     public static final String PATH_MATCH_SCORES = "pathMatchScores";
     public static final String METHOD_MATCH = "methodMatch";
     public static final String HEADERS_MATCH_SCORE = "headersMatchScore";
+    public static final String QUERY_MATCH_SCORE = "queryMatchScore";
     public static final String BODY_PATH = "bodyPath";
     public static final String SERVER_PORT = "serverPort";
     

--- a/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
@@ -71,6 +71,7 @@ public class ScriptBindings implements Bindings {
     public static final String HEADER_CONTAINS = "headerContains";
     public static final String PARAM_VALUE = "paramValue";
     public static final String PARAM_CONTAINS = "paramContains";
+    public static final String PARAM_EXISTS = "paramExists";
     public static final String PATH_PARAMS = "pathParams";
     public static final String PATH_MATCH_SCORES = "pathMatchScores";
     public static final String METHOD_MATCH = "methodMatch";

--- a/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptBindings.java
@@ -70,7 +70,6 @@ public class ScriptBindings implements Bindings {
     public static final String ACCEPT_CONTAINS = "acceptContains";
     public static final String HEADER_CONTAINS = "headerContains";
     public static final String PARAM_VALUE = "paramValue";
-    public static final String PARAM_CONTAINS = "paramContains";
     public static final String PARAM_EXISTS = "paramExists";
     public static final String PATH_PARAMS = "pathParams";
     public static final String PATH_MATCH_SCORES = "pathMatchScores";

--- a/karate-core/src/main/java/com/intuit/karate/ScriptValueMap.java
+++ b/karate-core/src/main/java/com/intuit/karate/ScriptValueMap.java
@@ -37,6 +37,7 @@ public class ScriptValueMap extends HashMap<String, ScriptValue> {
     public static final String VAR_RESPONSE_COOKIES = "responseCookies";
     public static final String VAR_RESPONSE_HEADERS = "responseHeaders";
     public static final String VAR_RESPONSE_STATUS = "responseStatus";
+    public static final String VAR_RESPONSE_DELAY = "responseDelay";
     public static final String VAR_RESPONSE_TIME = "responseTime";
     public static final String VAR_RESPONSE_TYPE = "responseType";
 

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
@@ -60,6 +60,14 @@ public class FeatureBackend {
         private final Scenario scenario;
         private final List<Integer> scores;
 
+        private static final List<Integer> DEFAULT_SCORES = Collections.unmodifiableList(Arrays.asList(0, 0, 0, 0, 0, 0));
+
+        public FeatureScenarioMatch(FeatureBackend featureBackend, Scenario scenario) {
+            this.scenario = scenario;
+            this.scores = DEFAULT_SCORES;
+            this.featureBackend = featureBackend;
+        }
+
         public FeatureScenarioMatch(FeatureBackend featureBackend, Scenario scenario, List<Integer> scores) {
             this.scenario = scenario;
             this.scores = Collections.unmodifiableList(scores);
@@ -123,6 +131,7 @@ public class FeatureBackend {
         putBinding(ScriptBindings.PATH_MATCHES, context);
         putBinding(ScriptBindings.METHOD_IS, context);
         putBinding(ScriptBindings.PARAM_VALUE, context);
+        putBinding(ScriptBindings.PARAM_CONTAINS, context);
         putBinding(ScriptBindings.TYPE_CONTAINS, context);
         putBinding(ScriptBindings.ACCEPT_CONTAINS, context);
         putBinding2(ScriptBindings.HEADER_CONTAINS, context);
@@ -177,9 +186,11 @@ public class FeatureBackend {
                 ScriptValue pathMatchScoresValue = context.vars.getOrDefault(ScriptBindings.PATH_MATCH_SCORES, ScriptValue.NULL);
                 boolean methodMatch = context.vars.getOrDefault(ScriptBindings.METHOD_MATCH, ScriptValue.FALSE).getValue(Boolean.class);
                 int headersMatchScore = context.vars.getOrDefault(ScriptBindings.HEADERS_MATCH_SCORE, ScriptValue.ZERO).getAsInt();
+                int queryMatchScore = context.vars.getOrDefault(ScriptBindings.QUERY_MATCH_SCORE, ScriptValue.ZERO).getAsInt();
 
                 scores.addAll(pathMatchScoresValue.isNull() ? Arrays.asList(0, 0, 0) : pathMatchScoresValue.getAsList());
                 scores.add(methodMatch ? 1 : 0);
+                scores.add(queryMatchScore);
                 scores.add(headersMatchScore);
 
                 matchingScenarios.add(new FeatureScenarioMatch(this, scenario, scores));

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
@@ -131,7 +131,6 @@ public class FeatureBackend {
         putBinding(ScriptBindings.PATH_MATCHES, context);
         putBinding(ScriptBindings.METHOD_IS, context);
         putBinding(ScriptBindings.PARAM_VALUE, context);
-        putBinding(ScriptBindings.PARAM_CONTAINS, context);
         putBinding(ScriptBindings.PARAM_EXISTS, context);
         putBinding(ScriptBindings.TYPE_CONTAINS, context);
         putBinding(ScriptBindings.ACCEPT_CONTAINS, context);
@@ -310,8 +309,6 @@ public class FeatureBackend {
         if (context.getConfig().isCorsEnabled()) {
             response.addHeader(HttpUtils.HEADER_AC_ALLOW_ORIGIN, "*");
         }
-        // functions here are outside of the 'transaction' and should not mutate global state !
-        // typically this is where users can set up an artificial delay or sleep
         if (afterScenario != null && afterScenario.isFunction()) {
             afterScenario.invokeFunction(context, null);
         }

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
@@ -255,21 +255,22 @@ public class FeatureBackend {
     public HttpResponse buildResponse(HttpRequest request, long startTime, Scenario scenario, ScriptValueMap args) {
         ScriptValue responseValue, responseStatusValue, responseHeaders, afterScenario, responseDelayValue;
         Map<String, Object> responseHeadersMap, configResponseHeadersMap;
-            ScriptValueMap result = handle(args, scenario);
-            ScriptValue configResponseHeaders = context.getConfig().getResponseHeaders();
-            responseValue = result.remove(ScriptValueMap.VAR_RESPONSE);
-            responseStatusValue = result.remove(ScriptValueMap.VAR_RESPONSE_STATUS);
-            responseDelayValue = result.remove(ScriptValueMap.VAR_RESPONSE_DELAY);
-            responseHeaders = result.remove(ScriptValueMap.VAR_RESPONSE_HEADERS);
-            afterScenario = result.remove(VAR_AFTER_SCENARIO);
-            if (afterScenario == null) {
-                afterScenario = context.getConfig().getAfterScenario();
-            }
-            configResponseHeadersMap = configResponseHeaders == null ? null : configResponseHeaders.evalAsMap(context);
-            responseHeadersMap = responseHeaders == null ? null : responseHeaders.evalAsMap(context);
+        ScriptValueMap result = handle(args, scenario);
+        ScriptValue configResponseHeaders = context.getConfig().getResponseHeaders();
+        responseValue = result.remove(ScriptValueMap.VAR_RESPONSE);
+        responseStatusValue = result.remove(ScriptValueMap.VAR_RESPONSE_STATUS);
+        long configResponseDelayValue = context.getConfig().getResponseDelay();
+        responseDelayValue = result.remove(ScriptValueMap.VAR_RESPONSE_DELAY);
+        responseHeaders = result.remove(ScriptValueMap.VAR_RESPONSE_HEADERS);
+        afterScenario = result.remove(VAR_AFTER_SCENARIO);
+        if (afterScenario == null) {
+            afterScenario = context.getConfig().getAfterScenario();
+        }
+        configResponseHeadersMap = configResponseHeaders == null ? null : configResponseHeaders.evalAsMap(context);
+        responseHeadersMap = responseHeaders == null ? null : responseHeaders.evalAsMap(context);
 
         int responseStatus = responseStatusValue == null ? 200 : Integer.valueOf(responseStatusValue.getAsString());
-        long delay = responseDelayValue == null || responseDelayValue.isNull() ? 0L : Double.valueOf(responseDelayValue.getAsString()).longValue();
+        long delay = responseDelayValue == null || responseDelayValue.isNull() ? configResponseDelayValue : Double.valueOf(responseDelayValue.getAsString()).longValue();
         HttpResponse response = new HttpResponse(startTime, System.currentTimeMillis());
         response.setStatus(responseStatus);
         response.setDelay(delay);

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
@@ -256,18 +256,18 @@ public class FeatureBackend {
     public HttpResponse buildResponse(HttpRequest request, long startTime, Scenario scenario, ScriptValueMap args) {
         ScriptValue responseValue, responseStatusValue, responseHeaders, afterScenario, responseDelayValue;
         Map<String, Object> responseHeadersMap, configResponseHeadersMap;
-        ScriptValueMap result = handle(args, scenario);
-        ScriptValue configResponseHeaders = context.getConfig().getResponseHeaders();
-        responseValue = result.remove(ScriptValueMap.VAR_RESPONSE);
-        responseStatusValue = result.remove(ScriptValueMap.VAR_RESPONSE_STATUS);
-        responseDelayValue = result.remove(ScriptValueMap.VAR_RESPONSE_DELAY);
-        responseHeaders = result.remove(ScriptValueMap.VAR_RESPONSE_HEADERS);
-        afterScenario = result.remove(VAR_AFTER_SCENARIO);
-        if (afterScenario == null) {
-            afterScenario = context.getConfig().getAfterScenario();
-        }
-        configResponseHeadersMap = configResponseHeaders == null ? null : configResponseHeaders.evalAsMap(context);
-        responseHeadersMap = responseHeaders == null ? null : responseHeaders.evalAsMap(context);
+            ScriptValueMap result = handle(args, scenario);
+            ScriptValue configResponseHeaders = context.getConfig().getResponseHeaders();
+            responseValue = result.remove(ScriptValueMap.VAR_RESPONSE);
+            responseStatusValue = result.remove(ScriptValueMap.VAR_RESPONSE_STATUS);
+            responseDelayValue = result.remove(ScriptValueMap.VAR_RESPONSE_DELAY);
+            responseHeaders = result.remove(ScriptValueMap.VAR_RESPONSE_HEADERS);
+            afterScenario = result.remove(VAR_AFTER_SCENARIO);
+            if (afterScenario == null) {
+                afterScenario = context.getConfig().getAfterScenario();
+            }
+            configResponseHeadersMap = configResponseHeaders == null ? null : configResponseHeaders.evalAsMap(context);
+            responseHeadersMap = responseHeaders == null ? null : responseHeaders.evalAsMap(context);
 
         int responseStatus = responseStatusValue == null ? 200 : Integer.valueOf(responseStatusValue.getAsString());
         long delay = responseDelayValue == null || responseDelayValue.isNull() ? 0L : Double.valueOf(responseDelayValue.getAsString()).longValue();

--- a/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeatureBackend.java
@@ -132,6 +132,7 @@ public class FeatureBackend {
         putBinding(ScriptBindings.METHOD_IS, context);
         putBinding(ScriptBindings.PARAM_VALUE, context);
         putBinding(ScriptBindings.PARAM_CONTAINS, context);
+        putBinding(ScriptBindings.PARAM_EXISTS, context);
         putBinding(ScriptBindings.TYPE_CONTAINS, context);
         putBinding(ScriptBindings.ACCEPT_CONTAINS, context);
         putBinding2(ScriptBindings.HEADER_CONTAINS, context);

--- a/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
@@ -160,7 +160,7 @@ public class FeaturesBackend {
 
             matches.addAll(featureMatches);
             if(defaultMatch != null)
-                defaults.add(new FeatureBackend.FeatureScenarioMatch(featureBackend, defaultMatch, Arrays.asList(0, 0, 0, 0, 0)));
+                defaults.add(new FeatureBackend.FeatureScenarioMatch(featureBackend, defaultMatch));
 
         }
         if(matches.isEmpty() && defaults.isEmpty()) {

--- a/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
@@ -89,41 +89,45 @@ public class FeaturesBackend {
         if("OPTIONS".equals(request.getMethod()) && isCorsEnabled()) {
             return corsCheck(request, startTime);
         }
-        //This is not expected to be an actual scenario
-        Match match = new Match()
-                .text(ScriptValueMap.VAR_REQUEST_URL_BASE, request.getUrlBase())
-                .text(ScriptValueMap.VAR_REQUEST_URI, request.getUri())
-                .text(ScriptValueMap.VAR_REQUEST_METHOD, request.getMethod())
-                .def(ScriptValueMap.VAR_REQUEST_HEADERS, request.getHeaders())
-                .def(ScriptValueMap.VAR_RESPONSE_STATUS, 200)
-                .def(ScriptValueMap.VAR_REQUEST_PARAMS, request.getParams());
-        byte[] requestBytes = request.getBody();
-        if (requestBytes != null) {
-            match.def(ScriptValueMap.VAR_REQUEST_BYTES, requestBytes);
-            String requestString = FileUtils.toString(requestBytes);
-            Object requestBody = requestString;
-            if (Script.isJson(requestString)) {
-                try {
-                    requestBody = JsonUtils.toJsonDoc(requestString);
-                } catch (Exception e) {
-                    getContext().logger.warn("json parsing failed, request data type set to string: {}", e.getMessage());
+        // this is a sledgehammer approach to concurrency !
+        // which is why for simulating 'delay', users should use the VAR_AFTER_SCENARIO (see end)
+        synchronized (this) { // BEGIN TRANSACTION !
+            //This is not expected to be an actual scenario
+            Match match = new Match()
+                    .text(ScriptValueMap.VAR_REQUEST_URL_BASE, request.getUrlBase())
+                    .text(ScriptValueMap.VAR_REQUEST_URI, request.getUri())
+                    .text(ScriptValueMap.VAR_REQUEST_METHOD, request.getMethod())
+                    .def(ScriptValueMap.VAR_REQUEST_HEADERS, request.getHeaders())
+                    .def(ScriptValueMap.VAR_RESPONSE_STATUS, 200)
+                    .def(ScriptValueMap.VAR_REQUEST_PARAMS, request.getParams());
+            byte[] requestBytes = request.getBody();
+            if (requestBytes != null) {
+                match.def(ScriptValueMap.VAR_REQUEST_BYTES, requestBytes);
+                String requestString = FileUtils.toString(requestBytes);
+                Object requestBody = requestString;
+                if (Script.isJson(requestString)) {
+                    try {
+                        requestBody = JsonUtils.toJsonDoc(requestString);
+                    } catch (Exception e) {
+                        getContext().logger.warn("json parsing failed, request data type set to string: {}", e.getMessage());
+                    }
+                } else if (Script.isXml(requestString)) {
+                    try {
+                        requestBody = XmlUtils.toXmlDoc(requestString);
+                    } catch (Exception e) {
+                        getContext().logger.warn("xml parsing failed, request data type set to string: {}", e.getMessage());
+                    }
                 }
-            } else if (Script.isXml(requestString)) {
-                try {
-                    requestBody = XmlUtils.toXmlDoc(requestString);
-                } catch (Exception e) {
-                    getContext().logger.warn("xml parsing failed, request data type set to string: {}", e.getMessage());
-                }
+                match.def(ScriptValueMap.VAR_REQUEST, requestBody);
             }
-            match.def(ScriptValueMap.VAR_REQUEST, requestBody);
+
+
+            FeatureBackend.FeatureScenarioMatch matchingInfo = getMatchingScenario(match.vars());
+            FeatureBackend matchingFeature = matchingInfo.getFeatureBackend();
+            Scenario matchingScenario = matchingInfo.getScenario();
+
+            return matchingFeature.buildResponse(request, startTime, matchingScenario, match.vars());
         }
-
-
-        FeatureBackend.FeatureScenarioMatch matchingInfo = getMatchingScenario(match.vars());
-        FeatureBackend matchingFeature = matchingInfo.getFeatureBackend();
-        Scenario matchingScenario = matchingInfo.getScenario();
-
-        return matchingFeature.buildResponse(request, startTime, matchingScenario, match.vars());
     }
 
     public HttpResponse corsCheck(HttpRequest request, long startTime) {

--- a/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/FeaturesBackend.java
@@ -128,6 +128,7 @@ public class FeaturesBackend {
 
             return matchingFeature.buildResponse(request, startTime, matchingScenario, match.vars());
         }
+        //Delays should be configured using def/configure responseDelay semantics instead of Thread.sleep
     }
 
     public HttpResponse corsCheck(HttpRequest request, long startTime) {

--- a/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
@@ -638,6 +638,7 @@ public class ScriptBridge implements PerfContext {
 
     public boolean pathMatches(String path) {
         String uri = getAsString(ScriptValueMap.VAR_REQUEST_URI);
+
         Map<String, String> pathParams = HttpUtils.parseUriPattern(path, uri);
         set(ScriptBindings.PATH_PARAMS, pathParams);
         boolean matched = pathParams != null;
@@ -674,6 +675,22 @@ public class ScriptBridge implements PerfContext {
             return list.get(0);
         }
         return list;
+    }
+
+    public boolean paramContains(String name, String test) {
+        Map<String, List<String>> params = (Map) getValue(ScriptValueMap.VAR_REQUEST_PARAMS).getValue();
+        if(params == null) {
+            return false;
+        }
+        List<String> values = params.getOrDefault(name, Collections.emptyList());
+        for(String value : values) {
+            if(value != null && value.contains(test)) {
+                int existingValue = (int) get(ScriptBindings.QUERY_MATCH_SCORE, 0);
+                set(ScriptBindings.QUERY_MATCH_SCORE, existingValue+1);
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean headerContains(String name, String test) {

--- a/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
@@ -664,11 +664,7 @@ public class ScriptBridge implements PerfContext {
     }
 
     public Object paramValue(String name) {
-        Map<String, List<String>> params = (Map) getValue(ScriptValueMap.VAR_REQUEST_PARAMS).getValue();
-        if (params == null) {
-            return null;
-        }
-        List<String> list = params.get(name);
+        List<String> list = paramValues(name);
         if (list == null) {
             return null;
         }
@@ -678,24 +674,17 @@ public class ScriptBridge implements PerfContext {
         return list;
     }
 
-    public boolean paramExists(String name) {
-        return paramContains(name, "");
+    private List<String> paramValues(String name) {
+        Map<String, List<String>> params = (Map) getValue(ScriptValueMap.VAR_REQUEST_PARAMS).getValue();
+        if (params == null) {
+            return null;
+        }
+        return params.get(name);
     }
 
-    public boolean paramContains(String name, String test) {
-        Map<String, List<String>> params = (Map) getValue(ScriptValueMap.VAR_REQUEST_PARAMS).getValue();
-        if(params == null) {
-            return false;
-        }
-        List<String> values = params.getOrDefault(name, Collections.emptyList());
-        for(String value : values) {
-            if(value != null && value.contains(test)) {
-                int existingValue = (int) get(ScriptBindings.QUERY_MATCH_SCORE, 0);
-                set(ScriptBindings.QUERY_MATCH_SCORE, existingValue+1);
-                return true;
-            }
-        }
-        return false;
+    public boolean paramExists(String name) {
+        List<String> list = paramValues(name);
+        return list != null && !list.isEmpty();
     }
 
     public boolean headerContains(String name, String test) {

--- a/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/ScriptBridge.java
@@ -497,7 +497,8 @@ public class ScriptBridge implements PerfContext {
                         result = JsonUtils.toJsonDoc(json);
                         context.logger.info("callSingleCache hit: {}", cacheFile);
                     } else {
-                        context.logger.info("callSingleCache stale, last modified {} - is before {} (minutes: {})", lastModified, since, minutes);
+                        context.logger.info("callSingleCache stale, last modified {} - is before {} (minutes: {})", lastModified, since,
+                                            minutes);
                     }
                 } else {
                     context.logger.info("callSingleCache file does not exist, will create: {}", cacheFile);
@@ -644,7 +645,7 @@ public class ScriptBridge implements PerfContext {
         boolean matched = pathParams != null;
 
         List<Integer> pathMatchScores = null;
-        if(matched) {
+        if (matched) {
             pathMatchScores = HttpUtils.calculatePathMatchScore(path);
         }
 
@@ -675,6 +676,10 @@ public class ScriptBridge implements PerfContext {
             return list.get(0);
         }
         return list;
+    }
+
+    public boolean paramExists(String name) {
+        return paramContains(name, "");
     }
 
     public boolean paramContains(String name, String test) {

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpResponse.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpResponse.java
@@ -38,6 +38,7 @@ public class HttpResponse {
     private MultiValuedMap headers;
     private byte[] body;
     private int status;
+    private long delay;
     private final long startTime;
     private final long endTime;
 
@@ -79,8 +80,16 @@ public class HttpResponse {
         return status;
     }
 
+    public long getDelay() {
+        return delay;
+    }
+
     public void setStatus(int status) {
         this.status = status;
+    }
+
+    public void setDelay(long delay) {
+        this.delay = delay;
     }
 
     public void setBody(byte[] body) {

--- a/karate-core/src/test/java/com/intuit/karate/core/simple1.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/simple1.feature
@@ -2,9 +2,7 @@
 Feature: simple 1
 
 Background:
-* print 'background: sleeping ...'
-* java.lang.Thread.sleep(1000)
-* print 'background: done'
+* configure responseDelay = 1000
 
 Scenario: 1-one
 * print '1-one'

--- a/karate-core/src/test/java/com/intuit/karate/http/HttpUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/http/HttpUtilsTest.java
@@ -4,6 +4,7 @@ import com.intuit.karate.FileUtils;
 import com.intuit.karate.Match;
 import com.intuit.karate.StringUtils;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -56,6 +57,26 @@ public class HttpUtilsTest {
         Match.equals(map, "{ id: '1' }");
         map = HttpUtils.parseUriPattern("/api/{img}", "/api/billie.jpg");
         Match.equals(map, "{ img: 'billie.jpg' }");
+        map = HttpUtils.parseUriPattern("/{greedyPath:.+}", "/cats/1");
+        Match.equals(map, "{ greedyPath: 'cats/1' }");
+        map = HttpUtils.parseUriPattern("/cats/v{partialPath}x", "/cats/v1x");
+        Match.equals(map, "{ partialPath: '1' }");
+        map = HttpUtils.parseUriPattern("/cats/{duplicate}/{duplicate}", "/cats/v1/1043");
+        Match.equals(map, "{ duplicate: 'v1', 'duplicate@2': '1043' }");
+        map = HttpUtils.parseUriPattern("/cats/{}/{}", "/cats/v1/1043");
+        Match.equals(map, "{ ignored: 'v1', 'ignored@2': '1043' }");
+    }
+
+    @Test
+    public void testCalculatePathMatchScore() {
+        List<Integer> score = HttpUtils.calculatePathMatchScore("/cats/{id}");
+        Match.equals(score, "[6,1,0]");
+        score = HttpUtils.calculatePathMatchScore("/cats/1");
+        Match.equals(score, "[7,0,0]");
+        score = HttpUtils.calculatePathMatchScore("/cats/1/");
+        Match.equals(score, "[7,0,0]");
+        score = HttpUtils.calculatePathMatchScore("cats/1/");
+        Match.equals(score, "[7,0,0]");
     }
 
     @Test

--- a/karate-demo/src/test/java/mock/contract/payment-service-proxy.feature
+++ b/karate-demo/src/test/java/mock/contract/payment-service-proxy.feature
@@ -6,10 +6,11 @@ Background:
 Scenario: pathMatches('/payments') && methodIs('post')
     * karate.proceed(paymentServiceUrl)
     # example of adding delay via a post-processing hook
-    # * def afterScenario = function(){ karate.log('sleeping ..'); java.lang.Thread.sleep(3000); }
+    * def responseDelay = 3000
 
 Scenario: pathMatches('/payments')
     * karate.proceed(paymentServiceUrl)
+    * def responseDelay = 200 + Math.random() * 400
 
 Scenario: pathMatches('/payments/{id}') && methodIs('delete')
     * karate.proceed(paymentServiceUrl)

--- a/karate-demo/src/test/java/mock/proxy/demo-mock-proceed.feature
+++ b/karate-demo/src/test/java/mock/proxy/demo-mock-proceed.feature
@@ -7,7 +7,7 @@ Background:
 * def targetUrlBase = demoServerPort ? 'http://127.0.0.1:' + demoServerPort : null
 * print 'init target url:', targetUrlBase
 
-Scenario: pathMatches('/greeting') && paramValue('name') != null
+Scenario: pathMatches('/greeting') && paramExists('name', '')
     * karate.proceed(targetUrlBase)
 
 # 'catch-all' rule

--- a/karate-demo/src/test/java/mock/proxy/demo-mock.feature
+++ b/karate-demo/src/test/java/mock/proxy/demo-mock.feature
@@ -5,7 +5,7 @@ Background:
 * def nextId = function(){ return ~~curId++ }
 * def cats = {}
 
-Scenario: pathMatches('/greeting') && paramValue('name') != null
+Scenario: pathMatches('/greeting') && paramExists('name')
     * def content = 'Hello ' + paramValue('name') + '!'
     * def response = { id: '#(nextId())', content: '#(content)' }
 

--- a/karate-gatling/src/test/scala/mock/mock.feature
+++ b/karate-gatling/src/test/scala/mock/mock.feature
@@ -3,7 +3,6 @@ Feature: cats stateful crud
   Background:
     * def uuid = function(){ return java.util.UUID.randomUUID() + '' }
     * def cats = {}
-    * def delay = function(){ java.lang.Thread.sleep(850) }
 
   Scenario: pathMatches('/cats') && methodIs('post')
     * def cat = request
@@ -22,7 +21,7 @@ Feature: cats stateful crud
   Scenario: pathMatches('/cats/{id}') && methodIs('delete')
     * karate.remove('cats', '$.' + pathParams.id)
     * def response = ''
-    * def afterScenario = delay
+    * def responseDelay = 850
 
   Scenario: pathMatches('/cats/{id}')
     * def response = cats[pathParams.id]

--- a/karate-jersey/pom.xml
+++ b/karate-jersey/pom.xml
@@ -19,6 +19,12 @@
             <groupId>com.intuit.karate</groupId>
             <artifactId>karate-core</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>        
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/karate-netty/README.md
+++ b/karate-netty/README.md
@@ -400,7 +400,7 @@ Scenario: pathMatches('/v1/headers') && karate.get('requestHeaders.val[0]') == '
 Note that you can define your custom JS re-usable functions in the `Background` which can make complex matching logic easier to implement.
 
 ## `requestParams`
-A map-like' object of all query-string parameters and the values will always be an array. The built-in convenience function [`paramValue()`](#paramValue) is what you would use most of the time.
+A map-like' object of all query-string parameters and the values will always be an array. The built-in convenience functions [`paramExists()`](#paramexists) and [`paramContains()`](#paramcontains) is what you would use most of the time.
 
 ## `pathMatches()`
 Helper function that makes it easy to match a URI pattern as well as set [path parameters](#pathparams) up for extraction later using curly-braces. For example:
@@ -421,11 +421,23 @@ Scenario: pathMatches('/v1/cats/{id}') && methodIs('get')
     * def response = cats[pathParams.id]
 ```
 
+## `paramExists()`
+Function (not a variable) designed to match request on query parameter instead of [`requestParams`](#requestparams). Returns a boolean.
+```cucumber
+Scenario: pathMatches('/greeting') && paramExists('name')
+```
+
+## `paramContains()`
+Function (not a variable) designed to match request on query parameter containing a string instead of [`requestParams`](#requestparams). Returns a boolean.
+```cucumber
+Scenario: pathMatches('/greeting') && paramContains('name', 'Bob')
+```
+
 ## `paramValue()`
 Function (not a variable) designed to make it easier to work with query parameters instead of [`requestParams`](#requestparams). It will return a single (string) value (instead of an array) if the size of the parameter-list for that name is 1, which is what you need most of the time. For example:
 
 ```cucumber
-Scenario: pathMatches('/greeting') && paramValue('name') != null
+Scenario: pathMatches('/greeting') && paramExists('name')
     * def content = 'Hello ' + paramValue('name') + '!'
     * def response = { id: '#(nextId())', content: '#(content)' }
 ```

--- a/karate-netty/README.md
+++ b/karate-netty/README.md
@@ -554,25 +554,43 @@ Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, HEAD, POST, PUT, DELETE, PATCH
 ```
 
-## `afterScenario`
-Use this to add an artificial delay instead of calling `Thread.sleep()` directly which will block all other threads. For example:
+## `responseDelay`
+You can easily set response delay in milliseconds
 
 ```cucumber
-* def afterScenario = function(){ java.lang.Thread.sleep(3000) }
+Scenario: pathMatches('/v1/test')
+    * def responseDelay = 4000
 ```
 
+## `def responseDelay`
+You can also configure a randomised delay across all scenarios. Here is an example of setting a random delay between 200 to 600 milliseconds:
+
+```cucumber
+Background:
+    * def responseDelay = 200 + Math.random() * 400
+```
 Refer to this example: [`payment-service-proxy.feature`](../karate-demo/src/test/java/mock/contract/payment-service-proxy.feature).
 
+## `afterScenario`
+Use this to add re-use any behaviour after scenario run, e.g. logging. For example:
+
+```cucumber
+* def afterScenario =
+"""
+function(){
+    karate.log('finished')
+}
+"""
+```
+
 ### `configure afterScenario`
-Just like the above, but you can set this "globally" for all route-handlers in the [`Background`](#background). Here is an example of setting a random delay between 200 to 600 milliseconds.
+Just like the above, but you can set this "globally" for all route-handlers in the [`Background`](#background).
 
 ```cucumber
 * configure afterScenario =
 """
 function(){
-    var millis = 200 + Math.random() * 400;
     karate.log('sleeping for:', millis, 'millis')
-    java.lang.Thread.sleep(millis); 
 }
 """
 ```

--- a/karate-netty/README.md
+++ b/karate-netty/README.md
@@ -400,7 +400,7 @@ Scenario: pathMatches('/v1/headers') && karate.get('requestHeaders.val[0]') == '
 Note that you can define your custom JS re-usable functions in the `Background` which can make complex matching logic easier to implement.
 
 ## `requestParams`
-A map-like' object of all query-string parameters and the values will always be an array. The built-in convenience functions [`paramExists()`](#paramexists) and [`paramContains()`](#paramcontains) is what you would use most of the time.
+A map-like' object of all query-string parameters and the values will always be an array. The built-in convenience function [`paramExists()`](#paramexists) is what you would use most of the time.
 
 ## `pathMatches()`
 Helper function that makes it easy to match a URI pattern as well as set [path parameters](#pathparams) up for extraction later using curly-braces. For example:
@@ -425,12 +425,6 @@ Scenario: pathMatches('/v1/cats/{id}') && methodIs('get')
 Function (not a variable) designed to match request on query parameter instead of [`requestParams`](#requestparams). Returns a boolean.
 ```cucumber
 Scenario: pathMatches('/greeting') && paramExists('name')
-```
-
-## `paramContains()`
-Function (not a variable) designed to match request on query parameter containing a string instead of [`requestParams`](#requestparams). Returns a boolean.
-```cucumber
-Scenario: pathMatches('/greeting') && paramContains('name', 'Bob')
 ```
 
 ## `paramValue()`


### PR DESCRIPTION
### Description
These are some of the suggestions mentioned in https://github.com/intuit/karate/pull/1159 that I hope to get feedback on.
- Declarative delays using `def responseDelay = 4000` can be used, which is then scheduled using netty Scheduler. This frees up any current implementations that use `Thread.sleep(4000)`
- Using full implementation of mock matching using reference Jersey implementation `org.glassfish.jersey.uri.internal.UriTemplateParser` which as a bonus also provides all the path scores required. This includes partial and greedy path matches.
- Inclusion of `paramContains()` for query matches which is considered AFTER the `methodIs()`. Would like your input on that @ptrthomas as currently with `paramValue()` it's not possible to capture a match. This could also be a regex match but I don't have any usecases for this to validate.

Thanks for contributing this Pull Request. Make sure that you submit this Pull Request against the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : (compulsory)
- Relevant PRs : (optional)
- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
